### PR TITLE
limit the architectures to build on

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,7 +5,9 @@ summary: Client for collecting data from charm-inventory-exporter
 description: |
   Collector designed to pull data exported by
   https://snapcraft.io/software-inventory-exporter
-
+architectures:
+  - build-on: amd64
+  - build-on: arm64
 grade: stable
 confinement: strict
 environment:


### PR DESCRIPTION
if not limited, github plugin tries to build on all architectures.